### PR TITLE
remove fixed width from "top user" badge tooltip

### DIFF
--- a/src/helper/Topuserbadge.js
+++ b/src/helper/Topuserbadge.js
@@ -5,7 +5,7 @@ import { Crown } from "@phosphor-icons/react";
 const Topuserbadge = () => {
   const [opened, { close, open }] = useDisclosure(false);
   return (
-    <Popover width={100} position="right" withArrow shadow="md" opened={opened}>
+    <Popover position="right" withArrow shadow="md" opened={opened}>
       <Popover.Target className="heartbeat-icon">
         <Crown
           onMouseEnter={open}


### PR DESCRIPTION
fixes issue: #2 
removes the fixed width of '100' from the top user badge tooltip.