### PR TITLE
remove fixed width from "Top User" badge tooltip.

### DIFF
--- a/src/helper/Topuserbadge.js
+++ b/src/helper/Topuserbadge.js
@@ -5,7 +5,7 @@ import { Crown } from "@phosphor-icons/react";
 const Topuserbadge = () => {
   const [opened, { close, open }] = useDisclosure(false);
   return (
-    <Popover width={100} position="right" withArrow shadow="md" opened={opened}>
+    <Popover position="right" withArrow shadow="md" opened={opened}>
       <Popover.Target className="heartbeat-icon">
         <Crown
           onMouseEnter={open}


### PR DESCRIPTION
Fixes Issue: #2 by removing the fixed width on the tooltip of the badge.
<img width="264" alt="image" src="https://github.com/Nawang17/momos-client/assets/64617857/117ddda8-5083-4a2d-89cf-dbc030560863">
